### PR TITLE
Reflect user intended update to question only when Ajax call is successful

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ group :development, :test do
   gem 'test-unit'
   gem 'poltergeist'
   gem 'phantomjs' #:require => 'phantomjs/poltergeist'
+  gem 'jasmine'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,12 @@ GEM
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (0.7.0)
+    jasmine (2.8.0)
+      jasmine-core (>= 2.8.0, < 3.0.0)
+      phantomjs
+      rack (>= 1.2.1)
+      rake
+    jasmine-core (2.8.0)
     journey (1.0.4)
     jquery-rails (3.1.2)
       railties (>= 3.0, < 5.0)
@@ -295,6 +301,7 @@ DEPENDENCIES
   googlecharts!
   haml
   highcharts-rails
+  jasmine
   jquery-rails
   json
   omniauth

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Travis CI](https://travis-ci.org/hrzlvn/coursequestionbank.svg?branch=master)](https://travis-ci.org/Laralinmcc/coursequestionbank)
 [![Test Coverage](https://codeclimate.com/github/hrzlvn/coursequestionbank/badges/coverage.svg)](https://codeclimate.com/github/Laralinmcc/coursequestionbank/coverage)
 <span style="background-color: blue; text-decoration:none; font: Verdana 7px bold; color:white; padding: 2px; margin: 2px;" ><a style="background-color: blue; text-decoration:none; font: Verdana 7px bold; color:white; padding: 2px; margin: 2px;" href="https://www.pivotaltracker.com/n/projects/1544183">PivotalTracker</a></span>
-[![Coverage Status](https://coveralls.io/repos/github/Laralinmcc/coursequestionbank/badge.svg?branch=fall2017_features)](https://coveralls.io/github/Laralinmcc/coursequestionbank?branch=fall2017_features)
 
 # Video Links
 

--- a/app/assets/javascripts/SetObsolete.js
+++ b/app/assets/javascripts/SetObsolete.js
@@ -1,16 +1,23 @@
 var SetObsolete = {
     setup: function() {
         $('.prob_obsolete').submit(function() {
-            $.ajax({
-                url: $(this).attr('action'),
-                type: 'PUT',
-                data: $(this).serialize()
-            });
             var button = $(this).find('input[type="submit"]');
             var field = $(this).find('input[name="obsolete"]');
             var obsolete = field.attr('value') === '1';
-            field.attr('value', obsolete ? '0' : '1');
-            button.attr('value', obsolete ? 'Obsolete' : 'Mark obsolete');
+            $.ajax({
+                context: this,
+                url: $(this).attr('action'),
+                type: 'PUT',
+                data: $(this).serialize(),
+                success: function() {
+                    field.attr('value', obsolete ? '0' : '1');
+                    button.attr('value', obsolete ? 'Obsolete' : 'Mark obsolete');
+                },
+                error: function() {
+                    if (obsolete) {alert("Error: Question not updated to \"Obsolete\"");}
+                    else {alert("Error: Question not updated to Mark \"Obsolete\"");}
+                }
+            });
             return false;
         });
     }

--- a/app/assets/javascripts/changeBloom.js
+++ b/app/assets/javascripts/changeBloom.js
@@ -5,38 +5,42 @@ var ChangeBloom = {
       var container = $(this);
       container.find('form').submit(function() {
         $.ajax({
+          context: this,
           url: $(this).attr('action'),
           type: 'PUT',
-          data: $(this).serialize()
+          data: $(this).serialize(),
+          success: function() { 
+            var button = $(this).find('input[type="submit"]');
+            var category = $(this).find('input[name="category"]').attr('value');
+    
+            // Reset all buttons to default action
+            container.find('form').each(function() {
+              var my_button = $(this).find('input[type="submit"]');
+              var my_category_field = $(this).find('input[name="category"]');
+              my_category_field.attr('value', my_button.attr('value'));
+            });
+    
+            // Set 'none' action for current button if appropriate
+            var category_field = $(this).find('input[name="category"]');
+            if (category !== 'none')
+              category_field.attr('value', 'none');
+    
+            // Stylize buttons based on action
+            container.find('form').each(function() {
+              var button = $(this).find('input[type="submit"]');
+              var category = $(this).find('input[name="category"]').attr('value');
+              button.removeClass('btn-default btn-info');
+              if (category === 'none')
+                button.addClass('btn-info');
+              else
+                button.addClass('btn-default');
+            });
+          },
+          error: function (xhr, ajaxOptions, thrownError) {
+            alert("Error: Bloom category not updated to \"" + category + "\"");
+          }
         });
-
-        var button = $(this).find('input[type="submit"]');
-        var category = $(this).find('input[name="category"]').attr('value');
-
-        // Reset all buttons to default action
-        container.find('form').each(function() {
-          var my_button = $(this).find('input[type="submit"]');
-          var my_category_field = $(this).find('input[name="category"]');
-          my_category_field.attr('value', my_button.attr('value'));
-        });
-
-        // Set 'none' action for current button if appropriate
-        var category_field = $(this).find('input[name="category"]');
-        if (category !== 'none')
-          category_field.attr('value', 'none');
-
-        // Stylize buttons based on action
-        container.find('form').each(function() {
-          var button = $(this).find('input[type="submit"]');
-          var category = $(this).find('input[name="category"]').attr('value');
-          button.removeClass('btn-default btn-info');
-          if (category === 'none')
-            button.addClass('btn-info');
-          else
-            button.addClass('btn-default');
-        });
-
-        return false;
+        return false; 
       });
     });
   }

--- a/app/assets/javascripts/changePrivacy.js
+++ b/app/assets/javascripts/changePrivacy.js
@@ -1,24 +1,30 @@
 var ChangePrivacy = {
     setup: function() {
         $('.prob_privacy').submit(function() {
-            var button = $(this).find('input[type="submit"]');
-
-            var newValue = button.attr('value');
-            if (newValue === "Public") {
-                newValue = "Share"
-            } else if (newValue === "Share") {
-                newValue = "Private"
-            } else {
-                newValue = "Public"
-            }
-
-            button.attr('value', newValue);
-            // $(this).find('input[name="privacy"]').attr('value', button.attr('value'));
-            debugger
             $.ajax({
+                context: this,
                 url: $(this).attr('action'),
                 type: 'PUT',
-                data: $(this).serialize()
+                data: $(this).serialize(),
+                success: function() {
+                    var button = $(this).find('input[type="submit"]');
+
+                    var newValue = button.attr('value');
+                    if (newValue === "Public") {
+                        newValue = "Share"
+                    } else if (newValue === "Share") {
+                        newValue = "Private"
+                    } else {
+                        newValue = "Public"
+                    }
+        
+                    button.attr('value', newValue);
+                    // $(this).find('input[name="privacy"]').attr('value', button.attr('value'));
+                    debugger
+                },
+                error: function(thrownError) {
+                    alert("Error: Privacy not updated to \"" + newValue + "\"");
+                }
             });
             return false;
         });

--- a/features/ajax_action.feature
+++ b/features/ajax_action.feature
@@ -1,7 +1,8 @@
+# PTID: 152415801
 Feature: User should be able to know if AJAX action succeeds or not (making AJAX atomic)
   As a student, 
   I want to to be able to know if my request went through the system
-  So that I do not have a confusing user experience 
+  So that I do not have a confusing user experience
 
 Background: 
   Given I am on the login page
@@ -10,18 +11,11 @@ Background:
   And I am on the CourseQuestionBank home page
   And I press "Remember"
   
-Scenario: I am online. 
+Scenario: The AJAX action does not succeed
   Given I press "Understand"
+  And the AJAX request does not succeed.
+  Then I should see "The AJAX action did not succeed."
   And I check "Understand"
-  Then I press "Search"
-  Then the question should be part of "Understand"
-  And I uncheck "Understand"
-  And I check "Remember"
-  Then I press "Search"
-  And the question should not be part of "Remember"
-
-Scenario: I am offline. 
-  Given I am offline 
-  And I press "Understand"
-  Then the "Understand" button should not be blue 
-  And the "Remember" button should be blue
+  And I press "Search"
+  Then I should see "No questions matched your search criteria"
+  

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -528,22 +528,6 @@ Then(/^I should see an alert saying "([^"]*)"$/) do |message|
   expect(alert_text).to eq(message)
 end
 
-Then(/^the question should be part of "(.*?)"$/) do |arg1|
-  pending # express the regexp above with the code you wish you had
-end
-
-Then(/^the question should not be part of "(.*?)"$/) do |arg1|
-  pending # express the regexp above with the code you wish you had
-end
-
-Given(/^I am offline$/) do
-  pending # express the regexp above with the code you wish you had
-end
-
-Then(/^the "(.*?)" button should not be blue$/) do |arg1|
-  pending # express the regexp above with the code you wish you had
-end
-
-Then(/^the "(.*?)" button should be blue$/) do |arg1|
+Given(/^the AJAX request does not succeed\.$/) do
   pending # express the regexp above with the code you wish you had
 end


### PR DESCRIPTION
Pivotal Tracker #ID: 152415801
This pull request encompasses changes to make sure that the UI for questions is always reflective of what is stored in the Active Record. Now updates to the view will only be displayed if the Ajax call for the change to the question the user would like to make succeeds. If it does not succeed javascript will render an alert. 

The bloomberg taxonomy, obselete, collection, and privacy are the aspects of questions that are now only updated if the ajax 'PUT' succeeds.