### PR TITLE
Questions per page limit feature

### DIFF
--- a/app/controllers/problems_controller.rb
+++ b/app/controllers/problems_controller.rb
@@ -19,6 +19,11 @@ class ProblemsController < ApplicationController
     end
 
     session[:filters][:page] = nil
+    if (params[:per_page]) and (params[:per_page].to_i > 60)
+        flash[:notice] = "Cannot view more than 60 questions at a time"
+    else
+      session[:filters] = session[:filters].merge params.slice(:page, :per_page) 
+    end
     session[:filters] = session[:filters].merge params.slice(:page, :per_page)
   end
 

--- a/app/controllers/problems_controller.rb
+++ b/app/controllers/problems_controller.rb
@@ -24,7 +24,6 @@ class ProblemsController < ApplicationController
     else
       session[:filters] = session[:filters].merge params.slice(:page, :per_page) 
     end
-    session[:filters] = session[:filters].merge params.slice(:page, :per_page)
   end
 
   def set_filters

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -20,7 +20,7 @@ module NavigationHelpers
     when /^the upload page$/ then '/upload'
     when /^the admin panel$/ then '/admin'
     when /^the login page$/ then '/auth/bypass/5'
-
+    when /^the page with more than sixty questions$/ then '/problems?per_page=100'
     when /^the collection search page$/ then '/collections' 
     when /^the collection index page$/ then '/collections' 
     when /^the collection search page of "(.*?)" $/ then '/collections' 


### PR DESCRIPTION
PTID # 152465497

At the moment, users can edit number of questions they can view per page in the url. Although it doesn't work there is no message for the user to realize this. Instead, it would be nice for the user to see this message.