### PR TITLE
[fix]removed duplicate sqlite3 gem from outside of the development gr…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,6 @@ gem 'jquery-rails'
 gem 'haml'
 gem 'zeroclipboard-rails'
 gem 'clipboard-rails'
-gem 'sqlite3'
 
 group :development, :test do
   gem 'cucumber-rails', :require => false


### PR DESCRIPTION
This pull request reverts the unnecessary duplicate sqlite3 gem from the gemfile. This sqlite3 gem is listed outside of the development group, which breaks deploying to heroku because sqlite3 is meant as a development only database.
