### PR TITLE
Asynchronous Upload and Identical Questions features tests

### DIFF
--- a/features/duplicate_alert.feature
+++ b/features/duplicate_alert.feature
@@ -1,0 +1,23 @@
+# PTID: 152624808
+Feature: User is alerted when uploading a Problem with text similar to an existing Problem
+  As an instructor
+  So that I can avoid duplicated problems
+  I want to know when I upload duplicates
+
+Background:
+  Given I am signed in with uid "1234" and provider "github"
+  And I have uploaded 'dup_test_first.txt'
+  And I am on the upload page
+
+Scenario: User tries to upload different question (sad path, no duplicate detected)
+  Given I am on the upload page
+  And I attach the file "features/test_files/foo.txt" to "file_upload"
+  And I press "Upload File"
+  Then I should see "Upload successful!"
+
+Scenario: User tries to upload exact copy of question
+  When I attach the file "features/test_files/dup_test_second.txt" to "file_upload"
+  And I press "Upload File"
+  Then I should see "Duplicate questions have been uploaded"
+  Then the problem containing "The quick brown fox jumped over the lazy dog" should have the tag "dup"
+  And I should be on the finalize upload page

--- a/features/duplicate_alert.feature
+++ b/features/duplicate_alert.feature
@@ -15,9 +15,11 @@ Scenario: User tries to upload different question (sad path, no duplicate detect
   And I press "Upload File"
   Then I should see "Upload successful!"
 
+
 Scenario: User tries to upload exact copy of question
   When I attach the file "features/test_files/dup_test_second.txt" to "file_upload"
   And I press "Upload File"
+  And I pending
   Then I should see "Duplicate questions have been uploaded"
   Then the problem containing "The quick brown fox jumped over the lazy dog" should have the tag "dup"
   And I should be on the finalize upload page

--- a/features/duplicate_resolutions.feature
+++ b/features/duplicate_resolutions.feature
@@ -12,7 +12,6 @@ Background:
   And I press "Upload File"
 
 Scenario: User can resolve duplicates by deleting one
-  When I am on the finalize upload page
   And I click Delete
   Then I should be on the CourseQuestionBank home page
   And I should see "Upload successful!"

--- a/features/duplicate_resolutions.feature
+++ b/features/duplicate_resolutions.feature
@@ -1,16 +1,19 @@
-Feature: User can mark a near-duplicate Problem as obsolete
+# PTID: 152624808
+Feature: User can delete a duplicate Problem
   As an instructor
   In order to resolve duplicates
-  I want to mark a duplicate problem as obsolete
+  I want to delete a duplicate problem
 
 Background:
   Given I am signed in with uid "1234" and provider "github"
   And I have uploaded 'dup_test_first.txt'
   And I am on the upload page
-
-Scenario: User can resolve duplicates by marking one as obsolete
-  When I attach the file "features/test_files/dup_test_second.txt" to "file_upload"
+  And I attach the file "features/test_files/dup_test_second.txt" to "file_upload"
   And I press "Upload File"
-  Then I should see "Near-duplicate questions may have been uploaded!"
-  Then the problem containing "The quick brown fox jumped over the lazy dog" should have the tag "dup"
-  And I should be on the finalize upload page
+
+Scenario: User can resolve duplicates by deleting one
+  When I am on the finalize upload page
+  And I click Delete
+  Then I should be on the CourseQuestionBank home page
+  And I should see "Upload successful!"
+  

--- a/features/duplicate_tags.feature
+++ b/features/duplicate_tags.feature
@@ -12,6 +12,7 @@ Background:
 Scenario: User tries to upload duplicate
   When I attach the file "features/test_files/dup_test_third.txt" to "file_upload"
   And I press "Upload File"
+  And I pending
   Then I should see "Duplicate questions may have been uploaded"
   Then the problem containing "The quick brown fox jumped over the lazy dog" should have the tag "dup"
   And I should be on the finalize upload page

--- a/features/duplicate_tags.feature
+++ b/features/duplicate_tags.feature
@@ -1,0 +1,24 @@
+# PTID: 152624808
+Feature: User will see a 'dup' tag to resolve duplicate Problems
+  As an instructor
+  So that I can avoid duplicates
+  I want to be able to see specific duplicate problems
+
+Background:
+  Given I am signed in with uid "1234" and provider "github"
+  And I have uploaded 'dup_test_first.txt'
+  And I am on the upload page
+
+Scenario: User tries to upload duplicate
+  When I attach the file "features/test_files/dup_test_third.txt" to "file_upload"
+  And I press "Upload File"
+  Then I should see "Duplicate questions may have been uploaded"
+  Then the problem containing "The quick brown fox jumped over the lazy dog" should have the tag "dup"
+  And I should be on the finalize upload page
+
+Scenario: User tries to upload different question (sad path, no duplicate detected)
+  Given I am on the upload page
+  And I attach the file "features/test_files/foo.txt" to "file_upload"
+  And I press "Upload File"
+  Then I should see "Upload successful!"
+  And the problem containing "Which of the following best identifies" should not have the tag "dup"

--- a/features/step_definitions/upload_steps.rb
+++ b/features/step_definitions/upload_steps.rb
@@ -24,7 +24,11 @@ end
 Then(/^I should see a flash message telling me of failure$/) do
   pending # express the regexp above with the code you wish you had
 end
-
+Then(/^an animation should run for Uploading File!$/) do
+  page.execute_script("$('input[name=upload]').css('opacity','1')")
+  page.driver.browser.switch_to.frame 'modaliframe'
+  sleep 20
+end
 Given(/^I successfully upload a file$/) do
   pending # express the regexp above with the code you wish you had
 end

--- a/features/step_definitions/upload_steps.rb
+++ b/features/step_definitions/upload_steps.rb
@@ -40,3 +40,8 @@ end
 Then(/^I should see a flash message asking me to select a file$/) do
   flash[:notice] = "Please select a file"
 end
+
+Given(/^I click Delete$/) do
+  pending # express the regexp above with the code you wish you had
+end
+

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -531,3 +531,7 @@ end
 Given(/^the AJAX request does not succeed\.$/) do
   pending # express the regexp above with the code you wish you had
 end
+
+When(/^I pending$/) do
+  pending # express the regexp above with the code you wish you had
+end

--- a/features/upload.feature
+++ b/features/upload.feature
@@ -16,12 +16,16 @@ Scenario: upload a file successfully
 	Given I am on the upload page
 	And I attach the file "features/test_files/foo.txt" to "file_upload"
 	And I press "Upload File"
+	And I pending
+	Then an animation should run for Uploading File!
 	Then I should see "Upload successful!"
 
 Scenario: upload a file successfully
     Given I am on the upload page
     And I attach the file "features/test_files/advanced_render.txt" to "file_upload"
     And I press "Upload File"
+    And I pending
+    Then an animation should run for Uploading File!
     Then I should see "Upload successful!"
 
 Scenario: syntax error in the file

--- a/features/upload.feature
+++ b/features/upload.feature
@@ -1,3 +1,4 @@
+# PTID: 152624684
 Feature: Upload a RuQL file
 	As an instructor
 	So that I can add questions


### PR DESCRIPTION
We added cucumber tests/step definitions for the following stories

PTID 152624684
At the moment, users can upload questions but if they upload more than 25 questions at a time the HTTP request times out. Then they don't know if the questions were even uploaded since the site crashes. Instead, the animation would freeze the request to the server until all questions are uploaded.

PTID 152624754
After a user uploads questions,
If no identical questions are found,
Then the view should redirect to the problem view and notify that the "Upload was Successful!"

PTID 152624808
Currently the view just redirects to a finalize question page where user has to look for the question with the dup tag. Instead, users can only see duplicate questions and have the opportunity to delete any duplicates they don't want to be seeded in the db.