### PR TITLE
Added student search feature file, fixed small typo

### DIFF
--- a/features/student_login.feature
+++ b/features/student_login.feature
@@ -1,5 +1,5 @@
 Feature: Student login
-    As an student
+    As a student
     So that I can access the application
 	  I want to login to the app with github
 	  

--- a/features/student_search.feature
+++ b/features/student_search.feature
@@ -1,0 +1,22 @@
+Feature: Student should be able to search for questions 
+  As a student, 
+  I want to to be able to search questions by typing in keywords
+  So that I narrow down the questions to study from 
+
+Background: 
+  Given I am signed in with uid "1234" and provider "github"
+  And I have uploaded 'foo.txt'
+  Then I am signed in with uid "12345" and provider "developer"
+  
+  And I am on the login page
+  And I follow "Log in with your GitHub account"
+  Then I should be on the problems page
+  And I should see "Student!"
+
+Scenario: searching by question text
+    # PTID 152770443
+    When I fill in "Search Keywords" with "HyperText Transfer Protocol"
+    And I press "Search"
+    Then I should not see "You don't have permission to access this page."
+    And I should see "RDBMS"
+    And I should not see "implied port number"


### PR DESCRIPTION
Added the following user story:

PT #152770443

As a student,
If I search for a keyword in the problems list,
Then I should see all the problems relevant to that keyword.

At the moment, users do not have access to the search functionality on the problems view. A flash message appears saying that they don't have permission to access the search page. The new feature file tests that the flash message should not appear and that the student successfully restricts the search results.

Also, made a quick typo fix to student_login.feature