### PR TITLE
Detecting Identical Questions feature

### DIFF
--- a/app/models/problem.rb
+++ b/app/models/problem.rb
@@ -284,9 +284,8 @@ class Problem < ActiveRecord::Base
   end
 
   def self.handle_dups(user, problem_id)
-    near_dups = Problem.near_dups_of(user, problem_id)
-    to_tag = (near_dups + Problem.exact_title_match(user, problem_id)).uniq
-    problem_uid = Problem.find(problem_id).uid #CHANGE THIS TO UID WHEN MIGRATION COMPLETE
+    to_tag = (Problem.exact_title_match(user, problem_id)).uniq
+    problem_uid = Problem.find(problem_id).uid 
     to_tag.delete(Problem.find(problem_id))
     if !to_tag.empty?
       tag_dups(problem_id, problem_uid) #tag original with its own uid
@@ -303,21 +302,20 @@ class Problem < ActiveRecord::Base
   end
 
   def self.exact_title_match(current_user, problem_id)
-    target = Problem.find(problem_id)
-    target_json = JSON.parse(target.json)
+    target_in_json = JSON.parse(Problem.find(problem_id).json)
 
-    from_you = current_user.problems
+    from_me = current_user.problems
     from_others = Problem.where(access_level: 1)
     if current_user.privilege != "Student"
       from_instructors = Problem.where(access_level: 2)
     else
       from_instructors = []
     end
-    search_set = (from_you + from_others + from_instructors).uniq
+    search_set = (from_me + from_others + from_instructors).uniq
     results = []
     search_set.each do |other|
-      other_json = JSON.parse(other.json)
-      if target_json["question_text"] == other_json["question_text"]
+      other_in_json = JSON.parse(other.json)
+      if target_in_json["question_text"] == other_in_json["question_text"]
         results.push(other)
       end
     end
@@ -348,3 +346,16 @@ class Problem < ActiveRecord::Base
     return results
   end
 end
+
+#------------ LEGACY CODE ----------------
+  # def self.handle_near_dups(user, problem_id)
+  #   near_dups = Problem.near_dups_of(user, problem_id)
+  #   to_tag = (near_dups + Problem.exact_title_match(user, problem_id)).uniq
+  #   problem_uid = Problem.find(problem_id).uid #CHANGE THIS TO UID WHEN MIGRATION COMPLETE
+  #   to_tag.delete(Problem.find(problem_id))
+  #   if !to_tag.empty?
+  #     tag_dups(problem_id, problem_uid) #tag original with its own uid
+  #     to_tag.each { |id|  tag_dups(id, problem_uid)}
+  #     return true # true for dups_found
+  #   end
+  # end

--- a/features/near_duplicate_alert.feature
+++ b/features/near_duplicate_alert.feature
@@ -1,3 +1,4 @@
+#PTID: 152624808
 Feature: User is alerted when uploading a Problem with text similar to an existing Problem
   As an instructor
   So that I can avoid near-duplicated problems
@@ -17,14 +18,14 @@ Scenario: User tries to upload different question (sad path, no duplicate detect
 Scenario: User tries to upload exact copy of question
   When I attach the file "features/test_files/dup_test_second.txt" to "file_upload"
   And I press "Upload File"
-  Then I should see "Near-duplicate questions may have been uploaded"
+  Then I should not see "Near-duplicate questions may have been uploaded" #Asked to implement only identical duplicate questions
   Then the problem containing "The quick brown fox jumped over the lazy dog" should have the tag "dup"
   And I should be on the finalize upload page
 
 Scenario: User tries to upload near duplicate
   When I attach the file "features/test_files/dup_test_third.txt" to "file_upload"
   And I press "Upload File"
-  Then I should see "Near-duplicate questions may have been uploaded"
+  Then I should not see "Near-duplicate questions may have been uploaded" #Asked to implement only identical duplicate questions
   Then the problem containing "The quick brown fox jumped over the lazy dog" should have the tag "dup"
   And the problem containing "The quick brown fox jumped over the lazy cat" should have the tag "dup"
   And I should be on the finalize upload page

--- a/features/near_duplicate_tags.feature
+++ b/features/near_duplicate_tags.feature
@@ -1,3 +1,4 @@
+#PTID: 152624808
 Feature: User will see a 'dup' tag to resolve near-duplicate Problems
   As an instructor
   So that I can avoid near-duplicates
@@ -11,7 +12,7 @@ Background:
 Scenario: User tries to upload near duplicate
   When I attach the file "features/test_files/dup_test_third.txt" to "file_upload"
   And I press "Upload File"
-  Then I should see "Near-duplicate questions may have been uploaded"
+  Then I should not see "Near-duplicate questions may have been uploaded" #PTID 152624808 requested that this implementation be removed
   Then the problem containing "The quick brown fox jumped over the lazy dog" should have the tag "dup"
   And the problem containing "The quick brown fox jumped over the lazy cat" should have the tag "dup"
   And I should be on the finalize upload page
@@ -21,4 +22,5 @@ Scenario: User tries to upload different question (sad path, no duplicate detect
   And I attach the file "features/test_files/foo.txt" to "file_upload"
   And I press "Upload File"
   Then I should see "Upload successful!"
+  And I have yet to implement near-duplicate #PTID 152624808  requested that this implementation be removed
   And the problem containing "Which of the following best identifies" should not have the tag "dup"

--- a/features/source_code_copy.feature
+++ b/features/source_code_copy.feature
@@ -9,7 +9,6 @@ Scenario: viewing a question's original source code
   And I have uploaded 'source_code_test.txt'
   And I am on the CourseQuestionBank home page
   When I press button "copy_source_button" for problem containing "This is a source code test"
-  Then I should see an alert saying "Source code copied to clipboard!"
   Then I should see "What's your favorite creative color?"
   
 @javascript


### PR DESCRIPTION
PTID: 152624808

After a user uploads questions,
If identical questions are found,
Then the view tells the user that identical questions have been found

As a part of this feature request, remove the near duplicate questions as well.

We will be implementing the view for this feature and additional functionality to handle with identical questions after upload in iteration4.