### PR TITLE
Put Code Climate Test Coverage back in the code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,6 @@ gem 'will_paginate'
 gem 'sunspot_solr'
 gem 'rollbar'
 gem "codeclimate-test-reporter", group: :test, require: nil
-gem 'coveralls', require: false
 gem "rails-settings-cached", "0.2.4"
 gem 'jquery-rails'
 gem 'haml'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
-require 'coveralls'
-Coveralls.wear!
+require 'codeclimate-test-reporter'
+CodeClimate::TestReporter.start
 
 require 'simplecov'
 SimpleCov.start 'rails'


### PR DESCRIPTION
Removing coveralls from spec_helper.rb

Since we are not using it at all its failing our Travis at the end and also might be a reason why maintainability is down.